### PR TITLE
Use long in constructor of context

### DIFF
--- a/EventbriteContext.cs
+++ b/EventbriteContext.cs
@@ -1,8 +1,10 @@
-﻿using EventbriteNET.Entities;
+﻿using System;
+using EventbriteNET.Entities;
 using EventbriteNET.HttpApi;
 
 namespace EventbriteNET
 {
+
     public class EventbriteContext
     {
         public string AppKey;
@@ -18,12 +20,12 @@ namespace EventbriteNET
             }
         }
 
-        public Organizer GetOrganizer(int id)
+        public Organizer GetOrganizer(long id)
         {
             return new Organizer(id, this);
         }
 
-        public Event GetEvent(int id)
+        public Event GetEvent(long id)
         {
             return new EventRequest(id, this).GetResponse();
         }


### PR DESCRIPTION
new organizer id's are too long to be int's
